### PR TITLE
update the section on histogram plotting

### DIFF
--- a/pyplot_histogram.jl
+++ b/pyplot_histogram.jl
@@ -20,7 +20,7 @@ nbins = 50 # Number of bins
 ##########
 fig = figure("pyplot_histogram",figsize=(10,10)) # Not strictly required
 ax = axes() # Not strictly required
-h = PyPlot.plt.hist(x,nbins) # Histogram, PyPlot.plt required to differentiate with conflicting hist command
+h = PyPlot.plt[:hist](x,nbins) # Histogram, PyPlot.plt[:hist] required for PyPlot versions v2.1.0 and above, otherwise replace Pyplot.plt[:hist] with Pyplot.plt.hist()
 
 grid("on")
 xlabel("X")


### PR DESCRIPTION
see the section titled "Exported functions" at the official PyPlot.jl GitHub page. PyPlot.plt.hist() no longer works for PyPlot v2.1.0 and above.